### PR TITLE
Create MenuItemReviewController, add GET (index) and POST (create)

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -1,0 +1,113 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+import java.time.LocalDateTime;
+
+@Tag(name = "MenuItemReview")
+@RequestMapping("/api/MenuItemReview")
+@RestController
+@Slf4j
+public class MenuItemReviewController  extends ApiController {
+
+    @Autowired
+    MenuItemReviewRepository menuItemReviewRepository;
+
+    @Operation(summary= "List all menu item reviews")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<MenuItemReview> allMenuItemReviews() {
+        Iterable<MenuItemReview> reviews = menuItemReviewRepository.findAll();
+        return reviews;
+    }
+
+    @Operation(summary= "Create a new menu item review")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public MenuItemReview postMenuItemReview(
+            @Parameter(name="itemId") @RequestParam long itemId,
+            @Parameter(name="reviewerEmail") @RequestParam String reviewerEmail,
+            @Parameter(name="stars") @RequestParam int stars,
+            @Parameter(description="Date reviewed (format YYYY-MM-DD)") @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDateTime dateReviewed,
+            @Parameter(name="comments") @RequestParam String comments)
+            throws JsonProcessingException {
+
+        log.info("dateReviewed={}", dateReviewed);
+        MenuItemReview menuItemReview = new MenuItemReview();
+        menuItemReview.setItemId(itemId);
+        menuItemReview.setReviewerEmail(reviewerEmail);
+        menuItemReview.setStars(stars);
+        menuItemReview.setDateReviewed(dateReviewed);
+        menuItemReview.setComments(comments);
+        MenuItemReview savedMenuItemReview = menuItemReviewRepository.save(menuItemReview);
+        return savedMenuItemReview;
+    }
+
+
+    @Operation(summary= "Get a single menu item review")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public MenuItemReview getById(
+            @Parameter(name="id") @RequestParam long id) {
+        MenuItemReview menuItemReview = menuItemReviewRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+        return menuItemReview;
+    }
+
+    @Operation(summary= "Delete a MenuItemReview")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteMenuItemReview(
+            @Parameter(name="id") @RequestParam long id) {
+        MenuItemReview menuItemReview = menuItemReviewRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+        
+        menuItemReviewRepository.delete(menuItemReview);
+        return genericMessage("MenuItemReview with id %s deleted".formatted(id));
+    }
+
+    @Operation(summary= "Update a single menu item review")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public MenuItemReview updateMenuItemReview(
+            @Parameter(name="id") @RequestParam long id,
+            @RequestBody @Valid MenuItemReview incoming) {
+        MenuItemReview menuItemReview = menuItemReviewRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+                menuItemReview.setItemId(incoming.getItemId());
+                menuItemReview.setReviewerEmail(incoming.getReviewerEmail());
+                menuItemReview.setStars(incoming.getStars());
+                menuItemReview.setDateReviewed(incoming.getDateReviewed());
+                menuItemReview.setComments(incoming.getComments());
+
+        menuItemReviewRepository.save(menuItemReview);
+        return menuItemReview;
+    }
+
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -66,48 +66,5 @@ public class MenuItemReviewController  extends ApiController {
         return savedMenuItemReview;
     }
 
-
-    @Operation(summary= "Get a single menu item review")
-    @PreAuthorize("hasRole('ROLE_USER')")
-    @GetMapping("")
-    public MenuItemReview getById(
-            @Parameter(name="id") @RequestParam long id) {
-        MenuItemReview menuItemReview = menuItemReviewRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
-
-        return menuItemReview;
-    }
-
-    @Operation(summary= "Delete a MenuItemReview")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @DeleteMapping("")
-    public Object deleteMenuItemReview(
-            @Parameter(name="id") @RequestParam long id) {
-        MenuItemReview menuItemReview = menuItemReviewRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
-        
-        menuItemReviewRepository.delete(menuItemReview);
-        return genericMessage("MenuItemReview with id %s deleted".formatted(id));
-    }
-
-    @Operation(summary= "Update a single menu item review")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @PutMapping("")
-    public MenuItemReview updateMenuItemReview(
-            @Parameter(name="id") @RequestParam long id,
-            @RequestBody @Valid MenuItemReview incoming) {
-        MenuItemReview menuItemReview = menuItemReviewRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
-
-                menuItemReview.setItemId(incoming.getItemId());
-                menuItemReview.setReviewerEmail(incoming.getReviewerEmail());
-                menuItemReview.setStars(incoming.getStars());
-                menuItemReview.setDateReviewed(incoming.getDateReviewed());
-                menuItemReview.setComments(incoming.getComments());
-
-        menuItemReviewRepository.save(menuItemReview);
-        return menuItemReview;
-    }
-
-
+    
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -51,7 +51,7 @@ public class MenuItemReviewController  extends ApiController {
             @Parameter(name="itemId") @RequestParam long itemId,
             @Parameter(name="reviewerEmail") @RequestParam String reviewerEmail,
             @Parameter(name="stars") @RequestParam int stars,
-            @Parameter(description="Date reviewed (format YYYY-MM-DD)") @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDateTime dateReviewed,
+            @Parameter(description="Date reviewed (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("dateReviewed") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateReviewed,
             @Parameter(name="comments") @RequestParam String comments)
             throws JsonProcessingException {
 

--- a/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
@@ -18,10 +18,10 @@ import lombok.Builder;
 @Builder
 @Entity(name = "menuitemreview")
 public class MenuItemReview {
-  
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
+
     private long itemId;
     private String reviewerEmail;
     private int stars;

--- a/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
@@ -1,0 +1,30 @@
+package edu.ucsb.cs156.example.entities;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.GeneratedValue;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "menuitemreview")
+public class MenuItemReview {
+  
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    private long itemId;
+    private String reviewerEmail;
+    private int stars;
+    private LocalDateTime dateReviewed;
+    private String comments;
+  }

--- a/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
@@ -1,0 +1,12 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MenuItemReviewRepository extends CrudRepository<MenuItemReview, Long> {
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
@@ -10,3 +10,5 @@ import java.util.List;
 public interface MenuItemReviewRepository extends CrudRepository<MenuItemReview, Long> {
 
 }
+
+

--- a/src/main/resources/db/migration/changes/MenuItemReview.json
+++ b/src/main/resources/db/migration/changes/MenuItemReview.json
@@ -1,0 +1,75 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "MenuItemReview-1",
+          "author": "XinyaoS",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "MENUITEMREVIEW"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "PK_MENUITEMREVIEW"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                    {
+                        "column": {
+                        "name": "ITEM_ID",
+                        "type": "BIGINT"
+                        }
+                    },
+                    {
+                        "column": {
+                        "name": "REVIEWER_EMAIL",
+                        "type": "VARCHAR(255)"
+                        }
+                    },
+                    {
+                        "column": {
+                        "name": "STARS",
+                        "type": "INT"
+                        }
+                    },
+                    {
+                        "column": {
+                        "name": "DATE_REVIEWED",
+                        "type": "TIMESTAMP"
+                        }
+                    },
+                    {
+                        "column": {
+                        "name": "COMMENTS",
+                        "type": "VARCHAR(255)"
+                        }
+                    }
+
+                ],
+                "tableName": "MENUITEMREVIEW"
+              }
+            }
+          ]
+        }
+      }
+    ]
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -1,0 +1,132 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = MenuItemReviewController.class)
+@Import(TestConfig.class)
+public class MenuItemReviewControllerTests extends ControllerTestCase {
+    @MockBean
+    MenuItemReviewRepository menuItemReviewRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    // Tests for GET /api/MenuItemReview/all
+
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+            mockMvc.perform(get("/api/MenuItemReview/all"))
+                            .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+            mockMvc.perform(get("/api/MenuItemReview/all"))
+                            .andExpect(status().is(200)); // logged
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_can_get_all_menu_item_review() throws Exception {
+
+            // arrange
+            LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+            MenuItemReview menuItemReview1 = MenuItemReview.builder()
+                            .itemId(1)
+                            .reviewerEmail("xinyaosong@ucsb.edu")
+                            .dateReviewed(ldt1)
+                            .comments("good")
+                            .stars(5)
+                            .build();
+
+            LocalDateTime ldt2 = LocalDateTime.parse("2022-03-11T00:00:00");
+
+            MenuItemReview menuItemReview2 = MenuItemReview.builder()
+                            .itemId(2)
+                            .reviewerEmail("bradygin@ucsb.edu")
+                            .dateReviewed(ldt2)
+                            .comments("bad")
+                            .stars(1)
+                            .build();
+
+            ArrayList<MenuItemReview> expectedReview = new ArrayList<>();
+            expectedReview.addAll(Arrays.asList(menuItemReview1, menuItemReview2));
+
+            when(menuItemReviewRepository.findAll()).thenReturn(expectedReview);
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/MenuItemReview/all"))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+
+            verify(menuItemReviewRepository, times(1)).findAll();
+            String expectedJson = mapper.writeValueAsString(expectedReview);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+    // Tests for POST /api/MenuItemReview/post...
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void an_admin_user_can_post_a_new_menu_item_review() throws Exception {
+            // arrange
+            LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
+
+            MenuItemReview menuItemReview1 = MenuItemReview.builder()
+                            .itemId(1)
+                            .reviewerEmail("xinyaosong@ucsb.edu")
+                            .dateReviewed(ldt)
+                            .comments("good")
+                            .stars(4)
+                            .build();
+
+            when(menuItemReviewRepository.save(eq(menuItemReview1))).thenReturn(menuItemReview1);
+
+            // act
+
+            MvcResult response = mockMvc.perform(
+                            post("/api/MenuItemReview/post?itemId=1&reviewerEmail=xinyaosong@ucsb.edu&stars=4&dateReviewed=2022-01-03T00:00:00&comments=good")
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(menuItemReviewRepository, times(1)).save(eq(menuItemReview1));
+            String expectedJson = mapper.writeValueAsString(menuItemReview1);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+}


### PR DESCRIPTION
Implemented a GET `/api/MenuItemReview/all` endpoint that returns a JSON list of all MenuItemReviews in the database and a POST `/api/MenuItemReview/post` endpoint that can be used to create a new entry in the table. 

Jacoco:
<img width="1185" alt="Screenshot 2024-04-30 at 4 12 23 PM" src="https://github.com/ucsb-cs156-s24/team02-s24-5pm-8/assets/42160992/c43e47d2-9699-4c1f-8617-bab7266e5218">

Pitest:
<img width="587" alt="Screenshot 2024-04-30 at 4 13 36 PM" src="https://github.com/ucsb-cs156-s24/team02-s24-5pm-8/assets/42160992/e555874f-cd8b-4671-912f-c8f33559814d">

Dokku Link: https://team02-xinyao-song-dev.dokku-16.cs.ucsb.edu

Closes #27